### PR TITLE
refactor(report): sprinkle in some CSP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   schedule:
     - cron: "0 0 * * 0" # Sunday at midnight
 
@@ -18,42 +18,36 @@ jobs:
           - nightly
           - 1.0.0
     steps:
-    -
-      name: Checkout release
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    -
-      name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-    -
-      name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    -
-      name: Set up Docker Cache
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ matrix.crystal }}-${{ github.sha }}
-    - 
-      name: Login to Docker Hub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-    - 
-      name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./Dockerfile
-        push: true
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
-        build-args: |
-          CRYSTAL_VERSION=${{ matrix.crystal }}
-        tags: placeos/drivers-spec:crystal-${{matrix.crystal}}
-        labels: |
-          org.opencontainers.image.vendor=Place Technology Limited
-          org.opencontainers.image.revision=${{ github.sha }}
-          org.opencontainers.image.title=PlaceOS/driver-spec-runner
+      - name: Checkout release
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ matrix.crystal }}-${{ github.sha }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          build-args: |
+            CRYSTAL_VERSION=${{ matrix.crystal }}
+          tags: placeos/drivers-spec:crystal-${{matrix.crystal}}
+          labels: |
+            org.opencontainers.image.vendor=Place Technology Limited
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.title=PlaceOS/driver-spec-runner

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
+report_failures
+
 # compiled output
 /frontend/dist
 /frontend/tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm install -g @angular/cli @angular-builders/custom-webpack && npm clean-in
 # Copy source after install dependencies
 COPY frontend /frontend
 
+# Build the frontend
 RUN npx ng build --prod
 
 ###########################
@@ -17,8 +18,12 @@ RUN npx ng build --prod
 FROM crystallang/crystal:${crystal_version}-alpine
 WORKDIR /app
 
-# Install the latest version of LibSSH2 and the GDB debugger
-RUN apk add --no-cache \
+# Install the latest version of
+# - libssh2
+# - [GDB debugger](https://sourceware.org/gdb/current/onlinedocs/gdb/)
+# - ping (via iputils)
+# - libyaml
+RUN apk add --update --no-cache \
   ca-certificates \
   gdb \
   iputils \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM node:${node_version}-alpine as frontend-build
 WORKDIR /frontend
 COPY /frontend/package*.json  /frontend
 
-RUN npm install -g @angular/cli @angular-builders/custom-webpack && npm clean-install
+RUN npm install -g @angular/cli @angular-builders/custom-webpack
+RUN npm clean-install
 
 # Copy source after install dependencies
 COPY frontend /frontend
@@ -19,15 +20,15 @@ FROM crystallang/crystal:${crystal_version}-alpine
 WORKDIR /app
 
 # Install the latest version of
-# - libssh2
 # - [GDB debugger](https://sourceware.org/gdb/current/onlinedocs/gdb/)
-# - ping (via iputils)
+# - libssh2
 # - libyaml
+# - ping (via iputils)
 RUN apk add --update --no-cache \
   ca-certificates \
   gdb \
   iputils \
-  libssh2 libssh2-dev libssh2-static \
+  libssh2-static \
   tzdata \
   yaml-static
 
@@ -45,10 +46,12 @@ RUN shards install --production --ignore-crystal-version
 COPY ./src /app/src
 COPY --from=frontend-build /frontend/dist/driver-spec-runner /app/www
 
-ENV PATH "$PATH:/app/bin"
+ENV PATH="$PATH:/app/bin"
 
 # Build App
 RUN shards build --error-trace --release --production --ignore-crystal-version
+
+RUN rm -r lib src
 
 # Run the app binding on port 8080
 EXPOSE 8080

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -22,7 +22,7 @@ RUN apk add --no-cache \
   gdb \
   bash \
   iputils \
-  libssh2 libssh2-dev libssh2-static \
+  libssh2-static \
   yaml-static
 
 RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing watchexec

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -42,9 +42,6 @@ COPY ./src /app/src
 COPY ./spec /app/spec
 COPY --from=frontend-build /frontend/dist/driver-spec-runner /app/www
 
-# Build src
-RUN shards build --error-trace --release --production --ignore-crystal-version
-
 COPY scripts/* /app/scripts/
 
 CMD /app/scripts/entrypoint.sh

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,6 @@ COPY frontend /frontend
 
 RUN npx ng build --prod
 
-
 FROM crystallang/crystal:${crystal_version}-alpine
 
 WORKDIR /app

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,23 +1,10 @@
-ARG node_version=12
 ARG crystal_version=1.0.0
-
-FROM node:${node_version}-alpine as frontend-build
-WORKDIR /frontend
-COPY /frontend/package*.json  /frontend/
-
-RUN npm install -g @angular/cli @angular-builders/custom-webpack && npm clean-install
-
-# Copy source after install dependencies
-COPY frontend /frontend
-
-RUN npx ng build --prod
-
 FROM crystallang/crystal:${crystal_version}-alpine
 
 WORKDIR /app
 
 # Install the latest version of LibSSH2 and the GDB debugger
-RUN apk add --no-cache \
+RUN apk add --update --no-cache \
   ca-certificates \
   gdb \
   bash \
@@ -36,12 +23,10 @@ COPY ./shard.yml /app/shard.yml
 COPY ./shard.override.yml /app/shard.override.yml
 COPY ./shard.lock /app/shard.lock
 
-RUN shards install --production --ignore-crystal-version
+RUN shards install --ignore-crystal-version
 
 COPY ./src /app/src
 COPY ./spec /app/spec
-COPY --from=frontend-build /frontend/dist/driver-spec-runner /app/www
-
 COPY scripts/* /app/scripts/
 
 CMD /app/scripts/entrypoint.sh

--- a/shard.lock
+++ b/shard.lock
@@ -5,6 +5,10 @@ shards:
     git: https://github.com/spider-gazelle/action-controller.git
     version: 4.5.0
 
+  ansi-escapes:
+    git: https://github.com/gtramontina/ansi-escapes.cr.git
+    version: 1.0.0
+
   connect-proxy:
     git: https://github.com/spider-gazelle/connect-proxy.git
     version: 1.4.0
@@ -35,6 +39,10 @@ shards:
 
   future:
     git: https://github.com/crystal-community/future.cr.git
+    version: 1.0.0
+
+  griffith:
+    git: https://github.com/gtramontina/griffith.cr.git
     version: 1.0.0
 
   habitat:
@@ -71,7 +79,7 @@ shards:
 
   placeos-driver:
     git: https://github.com/placeos/driver.git
-    version: 5.3.5
+    version: 5.3.14
 
   pool:
     git: https://github.com/ysbaddaden/pool.git
@@ -79,15 +87,15 @@ shards:
 
   promise:
     git: https://github.com/spider-gazelle/promise.git
-    version: 2.2.2
+    version: 2.2.3
 
   redis:
-    git: https://github.com/maiha/crystal-redis.git
-    version: 2.6.0
+    git: https://github.com/stefanwille/crystal-redis.git
+    version: 2.7.0
 
   redis-cluster:
     git: https://github.com/caspiano/redis-cluster.cr.git
-    version: 0.8.4
+    version: 0.8.5
 
   rendezvous-hash:
     git: https://github.com/caspiano/rendezvous-hash.git
@@ -95,7 +103,7 @@ shards:
 
   retriable: # Overridden
     git: https://github.com/sija/retriable.cr.git
-    version: 0.2.3
+    version: 0.2.4
 
   rwlock:
     git: https://github.com/spider-gazelle/readers-writer.git

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver-spec-runner
-version: 2.2.0
+version: 2.3.0
 
 # compile target
 targets:

--- a/shard.yml
+++ b/shard.yml
@@ -16,6 +16,9 @@ dependencies:
   exec_from:
     github: place-labs/exec_from
 
+  griffith:
+    github: gtramontina/griffith.cr
+
   pinger:
     github: spider-gazelle/pinger
 

--- a/spec/report_spec.cr
+++ b/spec/report_spec.cr
@@ -5,7 +5,7 @@ module PlaceOS::Drivers
     with_server do
       it "should have expected output" do
         io = IO::Memory.new
-        Process.run("crystal", {"run", "./src/report.cr", "--", "-p 6000", "--no-colour"}, output: io)
+        Process.run("crystal", {"run", "./src/report.cr", "--", "-p 6000"}, output: io)
         output = io.to_s
         output.should contain("1 drivers")
         output.should contain("0 failures")

--- a/src/report.cr
+++ b/src/report.cr
@@ -178,7 +178,6 @@ module PlaceOS::Drivers
       # Output report summary
 
       {% begin %}
-
       {% for status in Datum::State.constants.map(&.underscore) %}
         {{ status }} = state.select(&.{{ status }}?).map(&.value)
         puts "\n\n{{ status.gsub(/_/, " ") }}:\n * #{{{ status }}.join("\n * ")}" unless {{ status }}.empty?

--- a/src/report.cr
+++ b/src/report.cr
@@ -1,10 +1,187 @@
+require "atomic"
 require "colorize"
 require "griffith"
 require "http"
 require "json"
 require "option_parser"
 require "uri"
-require "atomic"
+
+module Settings
+  class_property host = "localhost"
+  class_property port = 8080
+  class_property repo = ""
+end
+
+module PlaceOS::Drivers
+  class Report
+    def initialize
+    end
+
+    record Datum, state : State, value : String do
+      enum State
+        CompileOnly
+        Failed
+        NoCompile
+        Timeout
+      end
+
+      forward_missing_to state
+
+      {% for state in State.constants %}
+        # Create a `State::{{ state }}`
+        def self.{{ state.underscore }}(value : String)
+          new State::{{ state }}, value
+        end
+      {% end %}
+    end
+
+    ###################################################################################################
+
+    getter tasks_lock : Mutex = Mutex.new
+    getter state_lock : Mutex = Mutex.new
+    getter tasks : Array(Griffith::Task) = [] of Griffith::Task
+    getter state : Array(Datum) = [] of Datum
+
+    record CompileOnly, driver : String, task : Griffith::Task
+    record Test, driver : String, spec : String, task : Griffith::Task
+
+    alias Build = CompileOnly | Test
+
+    getter done_channel : Channel(Nil) = Channel(Nil).new
+    getter build_channel : Channel(Build) = Channel(Build).new(2)
+    getter test_channel : Channel(Test) = Channel(Test).new(10)
+
+    getter tested : Atomic(Int32) = Atomic(Int32).new(0)
+
+    def stop
+      build_channel.close
+      test_channel.close
+      tasks_lock.synchronize { tasks.each &.fail("cancelled") }
+    end
+
+    def build(unit)
+      unit.task.details("compiling")
+      self.class.with_runner_client do |client|
+        client.read_timeout = 6.minutes
+        begin
+          response = client.post("/build?driver=#{unit.driver}")
+          if response.success?
+            if unit.is_a?(Test)
+              unit.task.details("builds")
+              test_channel.send(unit)
+            else
+              unit.task.done("builds")
+            end
+          else
+            unit.task.fail("failed to compile!")
+            unit.task.details("\n#{response.body}\n")
+            state_lock.synchronize { state << Datum.no_compile(unit.driver) }
+          end
+        rescue IO::TimeoutError
+          unit.task.fail("timeout")
+          state_lock.synchronize { state << Datum.timeout(unit.driver) }
+        end
+      end
+      mark_finished(unit) if unit.is_a? CompileOnly
+    end
+
+    def test(unit)
+      unit.task.done("testing")
+      tested.add(1)
+
+      params = URI::Params.new({
+        "driver" => [unit.driver],
+        "spec"   => [unit.spec],
+        "force"  => ["true"],
+      })
+
+      params["repository"] = Settings.repo unless Settings.repo.blank?
+      uri = URI.new(path: "/test", query: params)
+
+      self.class.with_runner_client do |client|
+        client.read_timeout = 6.minutes
+        begin
+          if client.post(uri.to_s).success?
+            unit.task.done("done")
+          else
+            unit.task.fail("failed")
+          end
+        rescue IO::TimeoutError
+          unit.task.fail("timeout")
+          state_lock.synchronize { state << Datum.timeout(unit.driver) }
+        end
+      end
+
+      mark_finished(unit)
+    end
+
+    def run(drivers : Array(String), specs : Array(String)) : Nil
+      # Build the drivers
+      spawn do
+        loop do
+          break unless unit = build_channel.receive?
+          build(unit)
+        end
+      end
+
+      # Test the drivers
+      spawn do
+        loop do
+          break unless unit = test_channel.receive?
+          test(unit)
+        end
+      end
+
+      drivers.each do |driver|
+        task = Griffith.create_task(driver)
+        tasks_lock.synchronize { tasks << task }
+        spec = "#{driver.rchop(".cr")}_spec.cr"
+        unit = if !specs.includes? spec
+                 CompileOnly.new(driver, task)
+               else
+                 Test.new(driver, spec, task)
+               end
+
+        build_channel.send(unit) rescue nil
+      end
+
+      drivers.size.times do
+        done_channel.receive?
+      end
+
+      # Output report summary
+
+      failed = state.select &.failed?
+      timeout = state.select &.timeout?
+      no_compile = state.select &.no_compile?
+      compile_only = state.select &.compile_only?
+
+      puts "\n\nspec failures:\n * #{failed.join("\n * ")}" if !failed.empty?
+      puts "\n\nspec timeouts:\n * #{timeout.join("\n * ")}" if !timeout.empty?
+      puts "\n\nfailed to compile:\n * #{no_compile.join("\n * ")}" if !no_compile.empty?
+      result_string = "\n\n#{tested.lazy_get} drivers, #{failed.size + no_compile.size} failures, #{timeout.size} timeouts, #{compile_only.size} without spec"
+      if timeout.empty? && failed.empty? && no_compile.empty?
+        puts result_string.colorize.green
+      else
+        puts result_string.colorize.red
+      end
+    end
+
+    # Helpers
+    ###################################################################################################
+
+    def mark_finished(unit)
+      tasks_lock.synchronize { tasks.delete(unit.task) }
+      done_channel.send(nil)
+    end
+
+    def self.with_runner_client
+      HTTP::Client.new(Settings.host, Settings.port) do |client|
+        yield client
+      end
+    end
+  end
+end
 
 module Settings
   class_property host = "localhost"
@@ -14,7 +191,6 @@ end
 
 OptionParser.parse(ARGV.dup) do |parser|
   parser.banner = "Usage: #{PROGRAM_NAME} [arguments]"
-
   parser.on("-h HOST", "--host=HOST", "Specifies the server host") { |h| Settings.host = h }
   parser.on("-p PORT", "--port=PORT", "Specifies the server port") { |p| Settings.port = p.to_i }
   parser.on("-r REPO", "--repo=REPO", "Specifies the repository to report on") { |r| Settings.repo = r }
@@ -23,187 +199,34 @@ end
 puts "running report against #{Settings.host}:#{Settings.port} (#{Settings.repo.presence ? "default " : Settings.repo + " "}repository)"
 
 # Driver discovery
-###################################################################################################
 
 print "discovering drivers... "
 
-response = with_runner_client &.get("/build")
+response = PlaceOS::Drivers::Report.with_runner_client &.get("/build")
 if !response.success?
-  puts "failed to obtain driver list"
-  exit 1
+  abort("failed to obtain driver list")
 end
 
 drivers = Array(String).from_json(response.body)
 puts "found #{drivers.size}"
 
 # Spec discovery
-###################################################################################################
 
 print "locating specs... "
 
-response = with_runner_client &.get("/test")
+response = PlaceOS::Drivers::Report.with_runner_client &.get("/test")
 if !response.success?
-  puts "failed to obtain spec list"
-  exit 2
+  abort("failed to obtain spec list")
 end
 
 specs = Array(String).from_json(response.body)
 puts "found #{specs.size}"
 
-###################################################################################################
-
-record Datum, state : State, value : String do
-  enum State
-    CompileOnly
-    Failed
-    NoCompile
-    Timeout
-  end
-
-  forward_missing_to state
-
-  {% for state in State.constants %}
-    # Create a `State::{{ state }}`
-    def self.{{ state.underscore }}(value : String)
-      new State::{{ state }}, value
-    end
-  {% end %}
-end
-
-###################################################################################################
-
-Griffith.config do |c|
-  # c.running_message "waiting"
-end
-
-tasks_lock = Mutex.new
-tasks = [] of Griffith::Task
-state_lock = Mutex.new
-state = [] of Datum
-
-record CompileOnly, driver : String, task : Griffith::Task
-record Test, driver : String, spec : String, task : Griffith::Task
-
-alias Build = CompileOnly | Test
-
-build_channel = Channel(Build).new(4)
-test_channel = Channel(Test).new(10)
+report = PlaceOS::Drivers::Report.new
 
 Signal::INT.trap do |signal|
-  build_channel.close
-  test_channel.close
-  tasks_lock.synchronize { tasks.each &.fail("cancelled") }
+  report.stop
   signal.ignore
 end
 
-tested = Atomic(Int32).new(0)
-
-# Build the drivers
-spawn do
-  loop do
-    break unless build = build_channel.receive?
-    build.task.details("compiling")
-    with_runner_client do |client|
-      client.read_timeout = 6.minutes
-      begin
-        if build?(build, client)
-          if build.is_a?(Test)
-            build.task.details("builds")
-            test_channel.send(build)
-          else
-            build.task.done("builds")
-          end
-        else
-          state_lock.synchronize { state << Datum.no_compile(build.driver) }
-        end
-      rescue IO::TimeoutError
-        build.task.fail("timeout")
-        state_lock.synchronize { state << Datum.timeout(build.driver) }
-      end
-    end
-    tasks_lock.synchronize { tasks.delete(build.task) } if build.is_a? CompileOnly
-  end
-end
-
-# Test the drivers
-spawn do
-  loop do
-    break unless build = test_channel.receive?
-    build.task.done("testing")
-    tested.add(1)
-
-    params = URI::Params.new({
-      "driver" => [build.driver],
-      "spec"   => [build.spec],
-      "force"  => ["true"],
-    })
-
-    params["repository"] = Settings.repo unless Settings.repo.blank?
-    uri = URI.new(path: "/test", query: params)
-
-    with_runner_client do |client|
-      client.read_timeout = 6.minutes
-      begin
-        if client.post(uri.to_s).success?
-          build.task.done("done")
-        else
-          build.task.fail("failed")
-        end
-      rescue IO::TimeoutError
-        build.task.fail("timeout")
-        state_lock.synchronize { state << Datum.timeout(build.driver) }
-      end
-    end
-    tasks_lock.synchronize { tasks.delete(build.task) }
-  end
-end
-
-drivers.each do |driver|
-  task = Griffith.create_task(driver)
-  tasks_lock.synchronize { tasks << task }
-  spec = "#{driver.rchop(".cr")}_spec.cr"
-  build = if !specs.includes? spec
-            CompileOnly.new(driver, task)
-          else
-            Test.new(driver, spec, task)
-          end
-
-  build_channel.send(build) rescue nil
-end
-
-# Output report
-###################################################################################################
-
-failed = state.select &.failed?
-timeout = state.select &.timeout?
-no_compile = state.select &.no_compile?
-compile_only = state.select &.compile_only?
-
-puts "\n\nspec failures:\n * #{failed.join("\n * ")}" if !failed.empty?
-puts "\n\nspec timeouts:\n * #{timeout.join("\n * ")}" if !timeout.empty?
-puts "\n\nfailed to compile:\n * #{no_compile.join("\n * ")}" if !no_compile.empty?
-result_string = "\n\n#{tested.lazy_get} drivers, #{failed.size + no_compile.size} failures, #{timeout.size} timeouts, #{compile_only.size} without spec"
-if timeout.empty? && failed.empty? && no_compile.empty?
-  puts result_string.colorize.green
-else
-  puts result_string.colorize.red
-end
-
-# Helpers
-###################################################################################################
-
-def with_runner_client
-  HTTP::Client.new(Settings.host, Settings.port) do |client|
-    yield client
-  end
-end
-
-def build?(build : Build, client)
-  response = client.post("/build?driver=#{build.driver}")
-  response.success?.tap do |built|
-    unless built
-      build.task.fail("failed to compile!")
-      build.task.details("\n#{response.body}\n")
-    end
-  end
-end
+report.run(drivers, specs)

--- a/src/report.cr
+++ b/src/report.cr
@@ -190,8 +190,8 @@ module PlaceOS::Drivers
 
     def log_compilation_failure(unit, io) : Nil
       path = unit.driver.lchop("drivers/").rchop(".cr").gsub('/', '_') + ".log"
-      File.open(log_directory / path) do |file_io|
-        file_io.copy(io)
+      File.open(log_directory / path, mode: "w+") do |file_io|
+        IO.copy(io, file_io)
       end
     rescue
       nil

--- a/src/report.cr
+++ b/src/report.cr
@@ -244,27 +244,20 @@ end
 
 puts "running report on drivers in `./drivers` against #{Settings.host}:#{Settings.port}"
 
-# Driver discovery
+# Driver and spec discovery
 
-print "discovering drivers... "
-response = PlaceOS::Drivers::Report.with_runner_client &.get("/build")
-abort("failed to obtain driver list") unless response.success?
+drivers, specs = {"drivers", "specs"}.map do |discover|
+  print "discovering #{discover}... "
+  path = discover == "drivers" ? "/build" : "/test"
+  response = PlaceOS::Drivers::Report.with_runner_client &.get(path)
+  abort("failed to obtain #{discover} list") unless response.success?
 
-drivers = Array(String).from_json(response.body)
-# Filter by files passed via the CLI, if any
-drivers = drivers.select &.in? Settings.passed_files unless Settings.passed_files.empty?
-puts "found #{drivers.size}"
-
-# Spec discovery
-
-print "locating specs... "
-response = PlaceOS::Drivers::Report.with_runner_client &.get("/test")
-abort("failed to obtain spec list") unless response.success?
-
-specs = Array(String).from_json(response.body)
-# Filter by files passed via the CLI, if any
-specs = specs.select &.in? Settings.passed_files unless Settings.passed_files.empty?
-puts "found #{specs.size}"
+  results = Array(String).from_json(response.body)
+  # Filter by files passed via the CLI, if any
+  results = results.select &.in? Settings.passed_files unless Settings.passed_files.empty?
+  puts "found #{results.size}"
+  results
+end
 
 report = PlaceOS::Drivers::Report.new
 

--- a/src/report.cr
+++ b/src/report.cr
@@ -69,6 +69,7 @@ module PlaceOS::Drivers
             if unit.is_a?(Test)
               unit.task.details("builds")
               test_channel.send(unit)
+              return
             else
               unit.task.done("builds")
             end
@@ -82,7 +83,8 @@ module PlaceOS::Drivers
           state_lock.synchronize { state << Datum.timeout(unit.driver) }
         end
       end
-      mark_finished(unit) if unit.is_a? CompileOnly
+
+      mark_finished(unit)
     end
 
     def test(unit)

--- a/src/report.cr
+++ b/src/report.cr
@@ -131,7 +131,7 @@ module PlaceOS::Drivers
       mark_finished(unit)
     end
 
-    def run(drivers : Array(String), specs : Array(String)) : Nil
+    def run(drivers : Array(String), specs : Array(String)) : Bool
       # Collect statistics
       spawn do
         while result = state_channel.receive?
@@ -185,12 +185,11 @@ module PlaceOS::Drivers
       {% end %}
 
       result_string = "\n\n#{tested.lazy_get} drivers, #{failed.size + no_compile.size} failures, #{timeout.size} timeouts, #{compile_only.size} without spec"
-      if timeout.empty? && failed.empty? && no_compile.empty?
-        puts result_string.colorize.green
-      else
-        puts result_string.colorize.red
-      end
 
+
+      (timeout.empty? && failed.empty? && no_compile.empty?).tap do |passed|
+        puts passed ? green result_string : red result_string
+      end
       {% end %}
     end
 
@@ -275,4 +274,4 @@ Signal::INT.trap do |signal|
   signal.ignore
 end
 
-report.run(drivers, specs)
+exit 1 unless report.run(drivers, specs)

--- a/src/report.cr
+++ b/src/report.cr
@@ -60,7 +60,7 @@ module PlaceOS::Drivers
     alias Build = CompileOnly | Test
 
     getter done_channel : Channel(Nil) = Channel(Nil).new
-    getter build_channel : Channel(Build) = Channel(Build).new(2)
+    getter build_channel : Channel(Build) = Channel(Build).new(1)
     getter test_channel : Channel(Test) = Channel(Test).new(10)
 
     getter tested : Atomic(Int32) = Atomic(Int32).new(0)

--- a/src/report.cr
+++ b/src/report.cr
@@ -88,7 +88,7 @@ module PlaceOS::Drivers
             else
               unit.task.fail(red "failed to compile!")
               state_channel.send Datum.no_compile(unit.driver)
-              spawn { log_compilation_failure(unit, response.body_io) }
+              spawn { log_compilation_failure(unit, response.body) }
             end
           end
         rescue IO::TimeoutError
@@ -207,10 +207,10 @@ module PlaceOS::Drivers
       done_channel.send(nil)
     end
 
-    def log_compilation_failure(unit, io) : Nil
+    def log_compilation_failure(unit, output) : Nil
       path = unit.driver.lchop("drivers/").rchop(".cr").gsub('/', '_') + ".log"
       File.open(log_directory / path, mode: "w+") do |file_io|
-        IO.copy(io, file_io)
+        file_io << output
       end
     rescue
       nil

--- a/src/report.cr
+++ b/src/report.cr
@@ -198,7 +198,7 @@ OptionParser.parse(ARGV.dup) do |parser|
   parser.on("-r REPO", "--repo=REPO", "Specifies the repository to report on") { |r| Settings.repo = r }
 end
 
-puts "running report against #{Settings.host}:#{Settings.port} (#{Settings.repo.presence ? "default " : Settings.repo + " "}repository)"
+puts "running report against #{Settings.host}:#{Settings.port} (#{Settings.repo.presence ? Settings.repo + " " : "default "} repository)"
 
 # Driver discovery
 

--- a/src/report.cr
+++ b/src/report.cr
@@ -184,9 +184,9 @@ puts "\n\nspec timeouts:\n * #{timeout.join("\n * ")}" if !timeout.empty?
 puts "\n\nfailed to compile:\n * #{no_compile.join("\n * ")}" if !no_compile.empty?
 result_string = "\n\n#{tested.lazy_get} drivers, #{failed.size + no_compile.size} failures, #{timeout.size} timeouts, #{compile_only.size} without spec"
 if timeout.empty? && failed.empty? && no_compile.empty?
-  puts result_string
+  puts result_string.colorize.green
 else
-  puts result_string
+  puts result_string.colorize.red
 end
 
 # Helpers


### PR DESCRIPTION
Incorporates `griffith` for a task renderer.

~One main issue is that failing output will clobber the renderer.~
~A solution would be rendering failures to a file.~
~A consequence of this could be keeping an archive of results.~

Logs compilation failures to the directory, `compilation_failures`