### PR TITLE
feat(report): allow varying parallel builds

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: placeos-driver-spec-runner
-version: 3.1.0
+version: 3.2.0
 
 # compile target
 targets:

--- a/src/report.cr
+++ b/src/report.cr
@@ -7,6 +7,7 @@ OptionParser.parse(ARGV.dup) do |parser|
   parser.on("-h HOST", "--host=HOST", "Specifies the server host") { |h| Settings.host = h }
   parser.on("-p PORT", "--port=PORT", "Specifies the server port") { |p| Settings.port = p.to_i }
   parser.on("-t TESTS", "--tests=TESTS", "Number of tests to run in parallel") { |t| Settings.tests = t.to_i }
+  parser.on("-b BUILDS", "--builds=BUILDS", "Number of drivers to compile in parallel") { |b| Settings.builds = b.to_i }
   parser.on("--no-colour", "Removes colour from the report") { Settings.no_colour = true }
   parser.on("--basic-render", "Stop CLI rendering tricks") { Settings.standard_render = false }
 

--- a/src/report/cli.cr
+++ b/src/report/cli.cr
@@ -70,7 +70,7 @@ module PlaceOS::Drivers
     alias Build = CompileOnly | Test
 
     getter done_channel : Channel(Nil) = Channel(Nil).new
-    getter build_channel : Channel(Build) = Channel(Build).new(1)
+    getter build_channel : Channel(Build) = Channel(Build).new(Settings.builds)
     getter test_channel : Channel(Test) = Channel(Test).new(Settings.tests)
 
     def stop

--- a/src/report/settings.cr
+++ b/src/report/settings.cr
@@ -3,6 +3,7 @@ module Settings
   class_property passed_files = [] of String
   class_property port = 8080
   class_property tests = 10
+  class_property builds = 1
   class_property? no_colour = false
   class_property? standard_render = true
 end


### PR DESCRIPTION
Enabled by `--builds` and `-b` args. Defaults to 1.